### PR TITLE
Tls no localhost

### DIFF
--- a/provider/mysql/mysqlProvider.go
+++ b/provider/mysql/mysqlProvider.go
@@ -17,7 +17,8 @@ import (
 )
 
 const (
-	dsn = "%v:%s@tcp(%s:%d)/zendb?charset=utf8&tls=skip-verify"
+	dsn_tls = "%v:%s@tcp(%s:%d)/zendb?charset=utf8&tls=skip-verify"
+	dsn = "%v:%s@tcp(%s:%d)/zendb?charset=utf8"
 )
 
 type MysqlConfig struct {
@@ -37,8 +38,13 @@ type MysqlProvider struct {
 }
 
 func Open(conf *MysqlConfig) *MysqlProvider {
-	db, err := sql.Open(conf.Type, fmt.Sprintf(dsn,
+        if conf.Hostname == "127.0.0.1" {
+	   db, err := sql.Open(conf.Type, fmt.Sprintf(dsn,
 		conf.User, conf.Password, conf.Hostname, conf.Port))
+        }else{
+	   db, err := sql.Open(conf.Type, fmt.Sprintf(dsn_tls,
+		conf.User, conf.Password, conf.Hostname, conf.Port))
+        }
 
 	err = db.Ping()
 

--- a/provider/mysql/mysqlProvider.go
+++ b/provider/mysql/mysqlProvider.go
@@ -38,11 +38,13 @@ type MysqlProvider struct {
 }
 
 func Open(conf *MysqlConfig) *MysqlProvider {
+        var db *sql.DB
+        var err error
         if conf.Hostname == "127.0.0.1" {
-	   db, err := sql.Open(conf.Type, fmt.Sprintf(dsn,
+	   db, err = sql.Open(conf.Type, fmt.Sprintf(dsn,
 		conf.User, conf.Password, conf.Hostname, conf.Port))
         }else{
-	   db, err := sql.Open(conf.Type, fmt.Sprintf(dsn_tls,
+	   db, err = sql.Open(conf.Type, fmt.Sprintf(dsn_tls,
 		conf.User, conf.Password, conf.Hostname, conf.Port))
         }
 


### PR DESCRIPTION
If localhost, then don't require tls.  
Why?  Besides testing, When you force TLS from a google hosted mysql, then you force a client certificate and key. 

Or, you can use a cloud_sql_proxy which does encrypt the data and connects in the end to the database with TLS, but is not TLS on a local node.

Also, changes to the TicketView